### PR TITLE
Remove notification when creating notes

### DIFF
--- a/src/noteCreator.ts
+++ b/src/noteCreator.ts
@@ -1,4 +1,4 @@
-import { App, Notice, TFile, TFolder, MarkdownView, moment, normalizePath } from 'obsidian';
+import { App, Notice, TFile, TFolder, moment, normalizePath } from 'obsidian';
 import { TemplateProcessor } from './templateProcessor';
 import { Commands } from './types';
 
@@ -40,8 +40,6 @@ export class NoteCreator {
 			
 			// Create the new file
 			const newFile = await this.app.vault.create(filePath, processedContent);
-			
-			new Notice(`Note created: ${newFile.basename}`);
 			
 			// Open the new file
 			await this.openFile(newFile);


### PR DESCRIPTION
## Summary
- Remove success notification that appears when creating a new note
- Keep error notifications for debugging purposes
- Clean up unused MarkdownView import

## Test plan
- [x] Install the plugin in Obsidian
- [x] Create a note using the template
- [x] Verify no notification appears on successful creation
- [x] Verify error notifications still appear when creation fails

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified note creation flow: after creating a note from a template, the new note opens immediately without a separate success notification. This reduces interruptions and speeds navigation. Existing behaviors for timestamped naming, folder creation, uniqueness checks, template processing, file creation/opening, and error handling remain unchanged.
- Chores
  - Cleaned up unused imports to reduce noise and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->