### PR TITLE
fix: Meet Obsidian plugin publishing requirements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,5 @@
 	"description": "Create new notes instantly from templates with custom commands and flexible destinations.",
 	"author": "YuMatsus",
 	"authorUrl": "https://github.com/YuMatsus",
-	"fundingUrl": "",
 	"isDesktopOnly": false
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,7 +25,7 @@ export class CommandManager {
 	registerCommands(): void {
 		// Register main command to create note from template
 		this.plugin.addCommand({
-			id: `${this.plugin.manifest.id}:create-note-from-template`,
+			id: 'create-note-from-template',
 			name: 'Create note from template',
 			callback: () => {
 				this.showTemplatePickerModal();
@@ -113,7 +113,7 @@ export class CommandManager {
 
 	private generateCommandId(name: string): string {
 		const slug = name.toLowerCase().trim().replace(/\s+/g, '-');
-		return `${this.plugin.manifest.id}:${slug}`;
+		return slug;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove empty fundingUrl field from manifest.json as per Obsidian requirements
- Fix command IDs to not include plugin ID (Obsidian auto-prefixes them)
- Verify all other publishing requirements are met

## Changes
- **manifest.json**: Removed empty `fundingUrl` field
- **src/commands.ts**: Updated `generateCommandId()` to return command ID without plugin prefix
- **src/commands.ts**: Fixed main command ID from `template-mint:create-note-from-template` to `create-note-from-template`

## Test plan
- [ ] Build the plugin with `npm run build`
- [ ] Install in Obsidian and verify all commands work correctly
- [ ] Check that command palette shows commands with correct IDs
- [ ] Verify custom commands from settings still function properly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Simplified command identifiers to plain slugs (previous namespace prefix removed). If you reference command IDs in custom hotkeys, workflows, or external scripts, update them to the new slug format.

- Chores
  - Removed the deprecated funding link from the application manifest.

- Notes
  - No changes to visible UI or behavior beyond command ID naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->