### PR TITLE
fix: Add security validation for path inputs

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -151,9 +151,10 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 					.setButtonText('Select')
 					.onClick(() => {
 						new FolderSearchModal(this.app, async (folder: TFolder) => {
-							// Validate that folder is within vault
-							if (this.isPathWithinVault(folder.path)) {
-								command.destinationFolder = folder.path;
+							// Normalize root path to empty string for UI consistency, then validate
+							const chosenPath = folder.path === '/' ? '' : folder.path;
+							if (this.isPathWithinVault(chosenPath)) {
+								command.destinationFolder = chosenPath;
 								await this.plugin.saveSettings();
 								this.display();
 							} else {
@@ -196,27 +197,30 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 	}
 
 	private isPathWithinVault(path: string): boolean {
+		// Normalize to POSIX, strip leading slashes (vault-relative)
+		const normalizedPath = path.replace(/\\/g, '/').replace(/^\/+/, '');
+
 		// Allow empty path (vault root)
-		if (path === '' || path === '/') {
+		if (normalizedPath === '') {
 			return true;
 		}
-		
-		// Ensure path doesn't contain parent directory references
-		if (path.includes('../') || path.includes('..\\')) {
+
+		// Block absolute Windows drive paths
+		if (/^[a-zA-Z]:/.test(path)) {
 			return false;
 		}
-		
-		// Ensure path doesn't start with absolute path indicators outside of vault
-		// Note: In Obsidian, paths are relative to vault root, so starting with / is not an issue
-		if (path.startsWith('\\') || /^[a-zA-Z]:/.test(path)) {
+
+		// Reject parent directory traversal
+		const segments = normalizedPath.split('/');
+		if (segments.some(seg => seg === '..')) {
 			return false;
 		}
-		
-		// Disallow hidden folders that might escape vault
-		if (path.startsWith('.')) {
+
+		// Reject hidden folders (starting with .)
+		if (segments.some(seg => seg.startsWith('.'))) {
 			return false;
 		}
-		
+
 		return true;
 	}
 
@@ -231,8 +235,13 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 			return true;
 		}
 		
-		// Check if template is within the configured template folder
-		return templatePath.startsWith(this.plugin.settings.templateFolder);
+		// Normalize paths for comparison
+		const normalizedTemplatePath = templatePath.replace(/\\/g, '/').replace(/^\/+/, '');
+		const normalizedTemplateFolder = this.plugin.settings.templateFolder.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+		
+		// Check if template is within the configured template folder (boundary-aware)
+		return normalizedTemplatePath === normalizedTemplateFolder || 
+			normalizedTemplatePath.startsWith(normalizedTemplateFolder + '/');
 	}
 }
 
@@ -254,9 +263,14 @@ class TemplateSearchModal extends FuzzySuggestModal<TFile> {
 			return files;
 		}
 		
-		// Filter files in the template folder
+		// Normalize template folder for comparison
+		const normalizedFolder = this.templateFolder.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+		
+		// Filter files in the template folder (boundary-aware)
 		return files.filter(file => {
-			return file.path.startsWith(this.templateFolder);
+			const normalizedPath = file.path.replace(/\\/g, '/').replace(/^\/+/, '');
+			return normalizedPath === normalizedFolder || 
+				normalizedPath.startsWith(normalizedFolder + '/');
 		});
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -49,9 +49,10 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 					.setButtonText('Select')
 					.onClick(() => {
 						new FolderSearchModal(this.app, async (folder: TFolder) => {
-							// Validate that folder is within vault
-							if (this.isPathWithinVault(folder.path)) {
-								this.plugin.settings.templateFolder = folder.path;
+							// Normalize root path to empty string for UI consistency, then validate
+							const chosenPath = folder.path === '/' ? '' : folder.path;
+							if (this.isPathWithinVault(chosenPath)) {
+								this.plugin.settings.templateFolder = chosenPath;
 								await this.plugin.saveSettings();
 								this.display();
 							} else {
@@ -124,8 +125,8 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 					.setButtonText('Select')
 					.onClick(() => {
 						new TemplateSearchModal(this.app, this.plugin.settings.templateFolder, async (file: TFile) => {
-							// Validate that template is within the template folder
-							if (this.isTemplateInValidFolder(file.path)) {
+							// Validate that template is within the configured template folder
+							if (this.isTemplateInConfiguredFolder(file.path)) {
 								command.templatePath = file.path;
 								await this.plugin.saveSettings();
 								this.display();
@@ -199,9 +200,11 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 	private isPathWithinVault(path: string): boolean {
 		// Normalize to POSIX, strip leading slashes (vault-relative)
 		const normalizedPath = path.replace(/\\/g, '/').replace(/^\/+/, '');
+		// Collapse duplicate slashes
+		const collapsedPath = normalizedPath.replace(/\/+/g, '/');
 
 		// Allow empty path (vault root)
-		if (normalizedPath === '') {
+		if (collapsedPath === '') {
 			return true;
 		}
 
@@ -210,8 +213,13 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 			return false;
 		}
 
+		// Block UNC/network-like paths: //server/share or \\server\share
+		if (/^(?:\\\\|\/\/)/.test(path)) {
+			return false;
+		}
+
 		// Reject parent directory traversal
-		const segments = normalizedPath.split('/');
+		const segments = collapsedPath.split('/');
 		if (segments.some(seg => seg === '..')) {
 			return false;
 		}
@@ -224,7 +232,7 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 		return true;
 	}
 
-	private isTemplateInValidFolder(templatePath: string): boolean {
+	private isTemplateInConfiguredFolder(templatePath: string): boolean {
 		// First check if path is within vault
 		if (!this.isPathWithinVault(templatePath)) {
 			return false;
@@ -259,8 +267,11 @@ class TemplateSearchModal extends FuzzySuggestModal<TFile> {
 		const files = this.app.vault.getMarkdownFiles();
 		
 		if (!this.templateFolder) {
-			// If no template folder is set, show all markdown files
-			return files;
+			// If no template folder is set, show all markdown files (excluding hidden)
+			return files.filter(file => {
+				const segments = file.path.split('/');
+				return !segments.some(seg => seg.startsWith('.'));
+			});
 		}
 		
 		// Normalize template folder for comparison
@@ -269,6 +280,11 @@ class TemplateSearchModal extends FuzzySuggestModal<TFile> {
 		// Filter files in the template folder (boundary-aware)
 		return files.filter(file => {
 			const normalizedPath = file.path.replace(/\\/g, '/').replace(/^\/+/, '');
+			// Exclude files in hidden folders
+			const segments = normalizedPath.split('/');
+			if (segments.some(seg => seg.startsWith('.'))) {
+				return false;
+			}
 			return normalizedPath === normalizedFolder || 
 				normalizedPath.startsWith(normalizedFolder + '/');
 		});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting, TFolder, FuzzySuggestModal, TFile } from 'obsidian';
+import { App, PluginSettingTab, Setting, TFolder, FuzzySuggestModal, TFile, Notice } from 'obsidian';
 import type TemplateMint from './main';
 
 export interface CommandConfig {
@@ -40,10 +40,7 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 				text
 					.setPlaceholder('Templates folder path')
 					.setValue(this.plugin.settings.templateFolder)
-					.onChange(async (value) => {
-						this.plugin.settings.templateFolder = value;
-						await this.plugin.saveSettings();
-					});
+					.setDisabled(true); // Make input read-only
 				
 				text.inputEl.style.width = '300px';
 			})
@@ -52,9 +49,14 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 					.setButtonText('Select')
 					.onClick(() => {
 						new FolderSearchModal(this.app, async (folder: TFolder) => {
-							this.plugin.settings.templateFolder = folder.path;
-							await this.plugin.saveSettings();
-							this.display();
+							// Validate that folder is within vault
+							if (this.isPathWithinVault(folder.path)) {
+								this.plugin.settings.templateFolder = folder.path;
+								await this.plugin.saveSettings();
+								this.display();
+							} else {
+								new Notice('Selected folder must be within the vault');
+							}
 						}).open();
 					});
 			});
@@ -114,10 +116,7 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 			.addText(text => {
 				text
 					.setValue(command.templatePath)
-					.onChange(async (value) => {
-						command.templatePath = value;
-						await this.plugin.saveSettings();
-					});
+					.setDisabled(true); // Make input read-only
 				text.inputEl.style.width = '200px';
 			})
 			.addButton(button => {
@@ -125,9 +124,14 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 					.setButtonText('Select')
 					.onClick(() => {
 						new TemplateSearchModal(this.app, this.plugin.settings.templateFolder, async (file: TFile) => {
-							command.templatePath = file.path;
-							await this.plugin.saveSettings();
-							this.display();
+							// Validate that template is within the template folder
+							if (this.isTemplateInValidFolder(file.path)) {
+								command.templatePath = file.path;
+								await this.plugin.saveSettings();
+								this.display();
+							} else {
+								new Notice('Template must be within the configured template folder');
+							}
 						}).open();
 					});
 			});
@@ -139,10 +143,7 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 			.addText(text => {
 				text
 					.setValue(command.destinationFolder)
-					.onChange(async (value) => {
-						command.destinationFolder = value;
-						await this.plugin.saveSettings();
-					});
+					.setDisabled(true); // Make input read-only
 				text.inputEl.style.width = '200px';
 			})
 			.addButton(button => {
@@ -150,9 +151,14 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 					.setButtonText('Select')
 					.onClick(() => {
 						new FolderSearchModal(this.app, async (folder: TFolder) => {
-							command.destinationFolder = folder.path;
-							await this.plugin.saveSettings();
-							this.display();
+							// Validate that folder is within vault
+							if (this.isPathWithinVault(folder.path)) {
+								command.destinationFolder = folder.path;
+								await this.plugin.saveSettings();
+								this.display();
+							} else {
+								new Notice('Selected folder must be within the vault');
+							}
 						}).open();
 					});
 			});
@@ -187,6 +193,46 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 	private generateCommandId(name: string): string {
 		const slug = name.toLowerCase().trim().replace(/\s+/g, '-');
 		return `${this.plugin.manifest.id}:${slug}`;
+	}
+
+	private isPathWithinVault(path: string): boolean {
+		// Allow empty path (vault root)
+		if (path === '' || path === '/') {
+			return true;
+		}
+		
+		// Ensure path doesn't contain parent directory references
+		if (path.includes('../') || path.includes('..\\')) {
+			return false;
+		}
+		
+		// Ensure path doesn't start with absolute path indicators outside of vault
+		// Note: In Obsidian, paths are relative to vault root, so starting with / is not an issue
+		if (path.startsWith('\\') || /^[a-zA-Z]:/.test(path)) {
+			return false;
+		}
+		
+		// Disallow hidden folders that might escape vault
+		if (path.startsWith('.')) {
+			return false;
+		}
+		
+		return true;
+	}
+
+	private isTemplateInValidFolder(templatePath: string): boolean {
+		// First check if path is within vault
+		if (!this.isPathWithinVault(templatePath)) {
+			return false;
+		}
+		
+		// If no template folder is configured, any vault file is valid
+		if (!this.plugin.settings.templateFolder) {
+			return true;
+		}
+		
+		// Check if template is within the configured template folder
+		return templatePath.startsWith(this.plugin.settings.templateFolder);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixed security vulnerability where users could access files outside vault through relative path manipulation
- Made all path input fields read-only, requiring picker UI for selection
- Added comprehensive path validation to prevent directory traversal attacks

## Changes
- Added `isPathWithinVault()` validation function to block:
  - Parent directory references (`../`)
  - Absolute path indicators
  - Hidden folders (including `.obsidian`)
- Added `isTemplateInValidFolder()` to ensure templates stay within configured folder
- Made template folder, template path, and destination folder inputs read-only
- Added validation checks to all folder/file selection handlers
- Added user notifications for invalid path selections

## Test plan
- [x] Verify input fields are read-only
- [x] Test folder picker only allows vault folders
- [x] Confirm vault root (`/`) selection works
- [x] Verify `.obsidian` folder cannot be selected
- [x] Test that templates must be within configured template folder
- [x] Confirm error messages appear for invalid selections

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Path input fields are now read-only; select folders and templates via dialogs.
  - Immediate in-app notices inform users when a selection is invalid.
  - Template picker/search now respects configured folder boundaries and excludes hidden folders.

- Bug Fixes
  - Prevent selecting folders or templates outside the vault.
  - Prevent selecting templates outside the configured template folder.
  - Normalize root folder representation and enforce consistent path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->