### PR TITLE
feat: Add default note name setting for template commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ While Obsidian's core Templates plugin allows you to insert templates into exist
    - **Command Name**: The name that appears in the command palette
    - **Template**: Select the template file to use
    - **Destination Folder**: Choose where new notes will be created
+   - **Default Note Name**: Set a default filename for new notes (supports template variables)
 
 ### Creating Notes
 
@@ -67,7 +68,16 @@ Example: `{{date:YYYY-MM-DD}}` → "2024-01-15"
 
 ## File Naming
 
-Notes are created with a 13-digit Unix timestamp (milliseconds) as the filename, ensuring uniqueness and chronological ordering.
+By default, notes are created with a 13-digit Unix timestamp (milliseconds) as the filename, ensuring uniqueness and chronological ordering.
+
+When a **Default Note Name** is configured for a command, the note will use that name instead. Template variables are supported:
+
+- `{{date}}` → `2024-01-15`
+- `{{time}}` → `14:30`
+- `{{date:YYYYMMDD}}` → `20240115`
+- `{{date:YYYY-[W]ww}}` → `2024-W03`
+
+Example: Setting `{{date}} Meeting Notes` creates a note named `2024-01-15 Meeting Notes.md`
 
 ## Development
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -79,7 +79,7 @@ export class CommandManager {
 	private async executeCommand(command: CommandConfig): Promise<void> {
 		try {
 			const templateFile = this.plugin.app.vault.getAbstractFileByPath(command.templatePath);
-			
+
 			if (!templateFile || !(templateFile instanceof TFile)) {
 				new Notice(`Template not found: ${command.templatePath}`);
 				return;
@@ -87,7 +87,8 @@ export class CommandManager {
 
 			await this.noteCreator.createNoteFromTemplate(
 				templateFile,
-				command.destinationFolder
+				command.destinationFolder,
+				command.defaultNoteName
 			);
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);

--- a/src/noteCreator.ts
+++ b/src/noteCreator.ts
@@ -17,12 +17,25 @@ export class NoteCreator {
 		this.templateProcessor = templateProcessor;
 	}
 
-	async createNoteFromTemplate(templateFile: TFile, destinationFolder: string): Promise<void> {
+	async createNoteFromTemplate(
+		templateFile: TFile,
+		destinationFolder: string,
+		defaultNoteName?: string
+	): Promise<void> {
 		try {
-			// Generate unique filename with 13-digit Unix timestamp (milliseconds)
-			const timestamp = moment().format('x');
-			const fileName = `${timestamp}.md`;
-			
+			// Generate filename
+			let fileName: string;
+			if (defaultNoteName) {
+				// Process template variables in the default note name
+				const processedName = this.templateProcessor.processFileNameVariables(defaultNoteName);
+				// Sanitize filename (remove invalid characters)
+				const sanitizedName = this.sanitizeFileName(processedName);
+				fileName = sanitizedName ? `${sanitizedName}.md` : `${moment().format('x')}.md`;
+			} else {
+				// Fallback to 13-digit Unix timestamp (milliseconds)
+				fileName = `${moment().format('x')}.md`;
+			}
+
 			// Construct file path
 			const rawFilePath = this.getFilePath(fileName, destinationFolder);
 			
@@ -55,9 +68,14 @@ export class NoteCreator {
 		if (!destinationFolder) {
 			return fileName;
 		}
-		
+
 		const normalizedDir = normalizePath(destinationFolder).replace(/\/+$/, '');
 		return normalizedDir ? `${normalizedDir}/${fileName}` : fileName;
+	}
+
+	private sanitizeFileName(name: string): string {
+		// Remove characters invalid in filenames: \ / : * ? " < > |
+		return name.replace(/[\\/:*?"<>|]/g, '').trim();
 	}
 
 	private async getUniqueFilePath(filePath: string): Promise<string> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ export interface CommandConfig {
 	name: string;
 	templatePath: string;
 	destinationFolder: string;
+	defaultNoteName: string;
 }
 
 export interface TemplateMintSettings {
@@ -165,6 +166,21 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 					});
 			});
 
+		// Default note name
+		new Setting(commandDiv)
+			.setName('Default Note Name')
+			.setDesc('Default name for new notes. Supports {{date}}, {{time}}, {{date:FORMAT}}, {{time:FORMAT}}. Leave empty for timestamp.')
+			.addText(text => {
+				text
+					.setPlaceholder('e.g. {{date}} Meeting Notes')
+					.setValue(command.defaultNoteName || '')
+					.onChange(async (value) => {
+						command.defaultNoteName = value;
+						await this.plugin.saveSettings();
+					});
+				text.inputEl.style.width = '300px';
+			});
+
 		// Delete button
 		new Setting(commandDiv)
 			.addButton(button => {
@@ -185,7 +201,8 @@ export class TemplateMintSettingTab extends PluginSettingTab {
 			id: this.generateUniqueCommandId(baseName),
 			name: baseName,
 			templatePath: '',
-			destinationFolder: ''
+			destinationFolder: '',
+			defaultNoteName: ''
 		};
 
 		this.plugin.settings.commands.push(newCommand);

--- a/src/templateProcessor.ts
+++ b/src/templateProcessor.ts
@@ -3,14 +3,27 @@ import { moment } from 'obsidian';
 export class TemplateProcessor {
 	processTemplateVariables(content: string, fileName: string): string {
 		const now = moment();
-		
+
 		let processedContent = content;
-		
+
 		// Core Obsidian Templates plugin compatible variables only
 		processedContent = processedContent.replace(/\{\{title\}\}/g, fileName.replace('.md', ''));
+		processedContent = this.processDateTimeVariables(processedContent, now);
+
+		return processedContent;
+	}
+
+	processFileNameVariables(template: string): string {
+		const now = moment();
+		return this.processDateTimeVariables(template, now);
+	}
+
+	private processDateTimeVariables(content: string, now: moment.Moment): string {
+		let processedContent = content;
+
 		processedContent = processedContent.replace(/\{\{date\}\}/g, now.format('YYYY-MM-DD'));
 		processedContent = processedContent.replace(/\{\{time\}\}/g, now.format('HH:mm'));
-		
+
 		// Custom format replacements - directly pass format to moment
 		processedContent = processedContent.replace(/\{\{date:([^}]+)\}\}/g, (match, format) => {
 			try {
@@ -19,7 +32,7 @@ export class TemplateProcessor {
 				return match;
 			}
 		});
-		
+
 		processedContent = processedContent.replace(/\{\{time:([^}]+)\}\}/g, (match, format) => {
 			try {
 				return now.format(format);
@@ -27,7 +40,7 @@ export class TemplateProcessor {
 				return match;
 			}
 		});
-		
+
 		return processedContent;
 	}
 }


### PR DESCRIPTION
## Summary
- Add `defaultNoteName` field to `CommandConfig` for configuring default note names per command
- Support template variables (`{{date}}`, `{{time}}`, `{{date:FORMAT}}`, `{{time:FORMAT}}`) in default note names
- Preserve original timestamp-based filename behavior when default note name is empty

## Test plan
- [x] Create a new template command and set a default note name (e.g., `{{date}} Meeting Notes`)
- [x] Execute the command and verify the new note is created with the processed filename
- [x] Verify template variables are correctly replaced in the filename
- [x] Leave default note name empty and verify timestamp-based filename is used
- [x] Test with invalid filename characters to verify sanitization works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure default note names per command (supports template variables)
  * Support date/time template variables with custom formats
  * Dynamic filename generation from processed template variables; invalid characters are automatically sanitized

* **Bug Fixes**
  * Show error notifications when note creation from templates fails

* **Documentation**
  * README updated with Default Note Name usage and filename examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->